### PR TITLE
Add Deribit isolated futures support

### DIFF
--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -155,6 +155,10 @@ BingX supports [time_in_force](configuration.md#understand-order_time_in_force) 
 !!! Tip "Stoploss on Exchange"
     Bingx supports `stoploss_on_exchange` and can use both stop-limit and stop-market orders. It provides great advantages, so we recommend to benefit from it by enabling stoploss on exchange.
 
+## Deribit
+
+Deribit supports isolated futures trading. Configure the bot with `"trading_mode": "futures"` and `"margin_mode": "isolated"` to enable futures on this exchange.
+
 ## Kraken
 
 Kraken supports [time_in_force](configuration.md#understand-order_time_in_force) with settings "GTC" (good till cancelled), "IOC" (immediate-or-cancel) and "PO" (Post only) settings.

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -12,6 +12,7 @@ from freqtrade.exchange.bitpanda import Bitpanda
 from freqtrade.exchange.bitvavo import Bitvavo
 from freqtrade.exchange.bybit import Bybit
 from freqtrade.exchange.cryptocom import Cryptocom
+from freqtrade.exchange.deribit import Deribit
 from freqtrade.exchange.exchange_utils import (
     ROUND_DOWN,
     ROUND_UP,

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -59,6 +59,7 @@ SUPPORTED_EXCHANGES = [
     "bingx",
     "bitmart",
     "bybit",
+    "deribit",
     "gate",
     "htx",
     "hyperliquid",

--- a/freqtrade/exchange/deribit.py
+++ b/freqtrade/exchange/deribit.py
@@ -1,0 +1,43 @@
+"""Deribit exchange subclass"""
+
+from __future__ import annotations
+
+import logging
+
+from freqtrade.enums import MarginMode, TradingMode
+from freqtrade.exchange import Exchange
+from freqtrade.exchange.exchange_types import FtHas
+
+
+logger = logging.getLogger(__name__)
+
+
+class Deribit(Exchange):
+    """Deribit exchange class.
+
+    Adds support for isolated futures trading on the Deribit exchange.
+    """
+
+    _ft_has: FtHas = {
+        "ws_enabled": True,
+    }
+
+    _ft_has_futures: FtHas = {
+        "stoploss_on_exchange": True,
+        "stoploss_order_types": {"limit": "limit", "market": "market"},
+        "stoploss_blocks_assets": False,
+    }
+
+    _supported_trading_mode_margin_pairs: list[tuple[TradingMode, MarginMode]] = [
+        (TradingMode.SPOT, MarginMode.NONE),
+        (TradingMode.FUTURES, MarginMode.ISOLATED),
+    ]
+
+    @property
+    def _ccxt_config(self) -> dict:
+        """Return ccxt configuration based on trading mode."""
+        config = super()._ccxt_config
+        if self.trading_mode == TradingMode.FUTURES:
+            config.setdefault("options", {})
+            config["options"].update({"defaultType": "future"})
+        return config

--- a/tests/exchange/test_deribit.py
+++ b/tests/exchange/test_deribit.py
@@ -1,0 +1,30 @@
+import sys
+import types
+
+from freqtrade.enums import MarginMode, TradingMode
+from tests.conftest import get_patched_exchange
+
+
+# Provide a minimal stub for the torch module so that tests don't require the real dependency.
+torch_module = types.ModuleType("torch")
+logging_module = types.ModuleType("_logging")
+logging_module._init_logs = lambda: None  # type: ignore[attr-defined]
+torch_module._logging = logging_module  # type: ignore[attr-defined]
+sys.modules.setdefault("torch", torch_module)
+
+
+def test_deribit_supports_isolated_futures(default_conf, mocker):
+    default_conf["trading_mode"] = TradingMode.FUTURES
+    default_conf["margin_mode"] = MarginMode.ISOLATED
+    exchange = get_patched_exchange(
+        mocker,
+        default_conf,
+        exchange="deribit",
+        mock_supported_modes=False,
+    )
+    assert (
+        TradingMode.FUTURES,
+        MarginMode.ISOLATED,
+    ) in exchange._supported_trading_mode_margin_pairs
+    ccxt_config = exchange._ccxt_config
+    assert ccxt_config.get("options", {}).get("defaultType") == "future"


### PR DESCRIPTION
## Summary
- add Deribit exchange class with isolated futures capabilities
- include Deribit in supported exchanges and docs
- cover Deribit futures in new unit test

## Testing
- `pre-commit run --files freqtrade/exchange/deribit.py freqtrade/exchange/__init__.py freqtrade/exchange/common.py docs/exchanges.md tests/exchange/test_deribit.py`
- `pytest tests/exchange/test_deribit.py`


------
https://chatgpt.com/codex/tasks/task_e_688f7f98aef083258fa32cd7d2750224